### PR TITLE
Telescope Umbrella chart

### DIFF
--- a/charts/telescope-argocd/.helmignore
+++ b/charts/telescope-argocd/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/telescope-argocd/Chart.yaml
+++ b/charts/telescope-argocd/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: telescope-argocd
+description: Chart to deploy Argo CD Applications Supporting Telescope
+version: 0.1.0

--- a/charts/telescope-argocd/templates/_helpers.tpl
+++ b/charts/telescope-argocd/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "telescope-argocd.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "telescope-argocd.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "telescope-argocd.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "telescope-argocd.labels" -}}
+helm.sh/chart: {{ include "telescope-argocd.chart" . }}
+{{ include "telescope-argocd.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "telescope-argocd.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "telescope-argocd.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "telescope-argocd.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "telescope-argocd.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/telescope-argocd/templates/application.yaml
+++ b/charts/telescope-argocd/templates/application.yaml
@@ -1,0 +1,28 @@
+{{- range $chartName, $chart := .Values.charts }}
+{{- if $chart.enabled }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ hasKey $.Values "applicationPrefix" | ternary (printf "%s-%s" $.Values.applicationPrefix (default $chartName $chart.name)) (default $chartName $chart.name) }}
+  namespace:  {{ default $.Values.gitOpsNamespace $chart.gitOpsNamespace }}
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: {{ default $.Release.Namespace (default $.Values.destinationNamespace $chart.destinationNamespace) }} 
+    server: {{ default $.Values.destinationServer $chart.destinationServer }}
+  project: {{ default "default" $chart.project }}
+  source:
+    chart: {{ default $chartName (default $chart.name $chart.repoChart) }}
+    repoURL: {{ default $.Values.repoURL $chart.repoURL }}
+    targetRevision: {{ default $.Values.chartVersion $chart.chartVersion }}
+    {{- if $chart.values }}
+    helm:
+      values: |
+        {{- toYaml $chart.values | nindent 8 }}
+    {{- end }}
+  syncPolicy:
+    {{- toYaml (default $.Values.defaultSyncPolicy $chart.syncPolicy) | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/telescope-argocd/values.schema.json
+++ b/charts/telescope-argocd/values.schema.json
@@ -1,0 +1,206 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+      "charts": {
+          "type": "object",
+          "properties": {
+              "postgresql": {
+                  "type": "object",
+                  "properties": {
+                      "enabled": {
+                          "type": "boolean",
+                          "examples": [
+                              true
+                          ]
+                      }
+                  },
+                  "examples": [{
+                      "enabled": true
+                  }]
+              },
+              "telescope-backend": {
+                  "type": "object",
+                  "properties": {
+                      "enabled": {
+                          "type": "boolean",
+                          "examples": [
+                              true
+                          ]
+                      }
+                  },
+                  "examples": [{
+                      "enabled": true
+                  }]
+              },
+              "telescope-frontend": {
+                  "type": "object",
+                  "properties": {
+                      "enabled": {
+                          "type": "boolean",
+                          "examples": [
+                              true
+                          ]
+                      }
+                  },
+                  "examples": [{
+                      "enabled": true
+                  }]
+              }
+          },
+          "examples": [{
+              "postgresql": {
+                  "enabled": true
+              },
+              "telescope-backend": {
+                  "enabled": true
+              },
+              "telescope-frontend": {
+                  "enabled": true
+              }
+          }]
+      },
+      "destinationServer": {
+          "type": "string",
+          "examples": [
+              "https://kubernetes.default.svc"
+          ]
+      },
+      "repoURL": {
+          "type": "string",
+          "examples": [
+              "https://rh-telescope.github.io/helm-charts"
+          ]
+      },
+      "chartVersion": {
+          "type": "string",
+          "examples": [
+              "x"
+          ]
+      },
+      "gitOpsNamespace": {
+          "type": "string",
+          "examples": [
+              "openshift-gitops"
+          ]
+      },
+      "defaultSyncPolicy": {
+          "type": "object",
+          "properties": {
+              "automated": {
+                  "type": "object",
+                  "properties": {
+                      "prune": {
+                          "type": "boolean",
+                          "examples": [
+                              false
+                          ]
+                      },
+                      "selfHeal": {
+                          "type": "boolean",
+                          "examples": [
+                              true
+                          ]
+                      }
+                  },
+                  "examples": [{
+                      "prune": false,
+                      "selfHeal": true
+                  }]
+              },
+              "retry": {
+                  "type": "object",
+                  "properties": {
+                      "limit": {
+                          "type": "integer",
+                          "examples": [
+                              5
+                          ]
+                      },
+                      "backoff": {
+                          "type": "object",
+                          "properties": {
+                              "duration": {
+                                  "type": "string",
+                                  "examples": [
+                                      "15s"
+                                  ]
+                              },
+                              "factor": {
+                                  "type": "integer",
+                                  "examples": [
+                                      2
+                                  ]
+                              },
+                              "maxDuration": {
+                                  "type": "string",
+                                  "examples": [
+                                      "5m"
+                                  ]
+                              }
+                          },
+                          "examples": [{
+                              "duration": "15s",
+                              "factor": 2,
+                              "maxDuration": "5m"
+                          }]
+                      }
+                  },
+                  "examples": [{
+                      "limit": 5,
+                      "backoff": {
+                          "duration": "15s",
+                          "factor": 2,
+                          "maxDuration": "5m"
+                      }
+                  }]
+              }
+          },
+          "examples": [{
+              "automated": {
+                  "prune": false,
+                  "selfHeal": true
+              },
+              "retry": {
+                  "limit": 5,
+                  "backoff": {
+                      "duration": "15s",
+                      "factor": 2,
+                      "maxDuration": "5m"
+                  }
+              }
+          }]
+      }
+  },
+  "examples": [{
+      "charts": {
+          "postgresql": {
+              "enabled": true
+          },
+          "telescope-backend": {
+              "enabled": true
+          },
+          "telescope-frontend": {
+              "enabled": true
+          }
+      },
+      "destinationServer": "https://kubernetes.default.svc",
+      "repoURL": "https://rh-telescope.github.io/helm-charts",
+      "chartVersion": "x",
+      "gitOpsNamespace": "openshift-gitops",
+      "defaultSyncPolicy": {
+          "automated": {
+              "prune": false,
+              "selfHeal": true
+          },
+          "retry": {
+              "limit": 5,
+              "backoff": {
+                  "duration": "15s",
+                  "factor": 2,
+                  "maxDuration": "5m"
+              }
+          }
+      }
+  }]
+}

--- a/charts/telescope-argocd/values.yaml
+++ b/charts/telescope-argocd/values.yaml
@@ -1,0 +1,32 @@
+---
+
+charts:
+  postgresql:
+    enabled: true
+  telescope-backend:
+    enabled: true
+  telescope-frontend:
+    enabled: true
+
+## Allows for prefixing the name of the Argo CD Application
+# applicationPrefix: prefix
+
+## Destination for Helm chart to be deployed (defaults to current namespace)
+## Can also be specified underneath each chart
+# destinationNamespace: prefix
+
+destinationServer: https://kubernetes.default.svc
+repoURL: https://rh-telescope.github.io/helm-charts
+chartVersion: x
+gitOpsNamespace: openshift-gitops
+
+defaultSyncPolicy:
+  automated:
+    prune: false
+    selfHeal: true
+  retry:
+    limit: 5
+    backoff:
+      duration: 15s
+      factor: 2
+      maxDuration: 5m


### PR DESCRIPTION
Umbrella chart to set up Argo CD Applications to deploy Telescope Helm Charts

Steps to install/test

1. Ensure Argo CD is already setup
    1. Provide necessary permissions to Argo CD to create resources
    2. Set `applicationInstanceLabelKey: argocd.argoproj.io/instance` in `ArgoCD` resource

2. Create a new namespace

```
oc new-project telescope
```

3. Install `telescope-argocd` helm chart

```
helm upgrade -i telescope-argocd telescope/telescope-argocd --set charts.telescope-frontend.values.backendUrl=https://telescope-backend-$(oc project -q).apps.$(oc get dns cluster -o jsonpath='{ .spec.baseDomain }')
```

Note: For testing, `telescope/telescope-argocd` must be the location of the git repository and chart