### PR TITLE
Added telescope-toggle chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ helm upgrade -i <release_name> telescope/<chart_name>
 
 ## Charts
 
+* [telescope-argocd](charts/telescope-argocd)
 * [telescope-frontend](charts/telescope-frontend)
 * [telescope-backend](charts/telescope-backend)
+* [telescope-toggle](charts/telescope-toggle)
 * [postgresql](charts/postgresql)
 

--- a/charts/telescope-toggle/.helmignore
+++ b/charts/telescope-toggle/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/telescope-toggle/Chart.yaml
+++ b/charts/telescope-toggle/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: telescope-toggle
+description: >-
+  A helm chart for Kubernetes to deploy the 'telescope-toggle' application.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0

--- a/charts/telescope-toggle/README.md
+++ b/charts/telescope-toggle/README.md
@@ -1,0 +1,59 @@
+# telescope-toggle
+
+The telescope-toggle for the [Telescope Project](https://rh-telescope.github.io/)
+
+## Quick Installation
+
+```shell
+helm dependency update .
+helm install [RELEASE_NAME] .
+```
+
+This command deploys the default configuration for the telescope-toggle chart. The [Parameters] section describes the various ways in which the chart can be configured.
+
+## Uninstallation
+
+```shell
+helm uninstall [RELEASE_NAME]
+```
+
+The previous command removes the previously installed chart.
+
+## Parameters
+
+The following table lists the configurable parameters of the telescope-toggle chart and their default values.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| image | string | `"quay.io/telescope/telescope-toggle:latest"` |  |
+| imagePullPolicy | string | `"Always"` |  |
+| nodeSelector | object | `{}` |  |
+| postgresql.adminPassword | string | `""` |  |
+| postgresql.database | string | `"telescope"` |  |
+| postgresql.external | bool | `false` |  |
+| postgresql.host | string | `"postgresql"` |  |
+| postgresql.password | string | `""` |  |
+| postgresql.port | int | `5432` |  |
+| postgresql.secretName | string | `"postgresql"` |  |
+| postgresql.username | string | `""` |  |
+| probe.livepath | string | `"/"` |  |
+| probe.readypath | string | `"/"` |  |
+| pullSecret.enabled | bool | `false` |  |
+| pullSecret.secretKey | string | `".dockerconfigjson"` |  |
+| pullSecret.secretName | string | `"pull-secret"` |  |
+| resources | string | `nil` |  |
+| route.annotations | object | `{}` |  |
+| route.enabled | bool | `true` |  |
+| route.hostname | string | `""` |  |
+| route.name | string | `"telescope-toggle"` |  |
+| route.path | string | `"/"` |  |
+| service.name | string | `"telescope-toggle"` |  |
+| service.port | int | `80` |  |
+| service.targetport | int | `8080` |  |
+| service.type | string | `"ClusterIP"` |  |
+| tolerations | list | `[]` |  |
+
+----------------------------------------------

--- a/charts/telescope-toggle/templates/_helpers.tpl
+++ b/charts/telescope-toggle/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "telescope-toggle.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "telescope-toggle.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "telescope-toggle.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "telescope-toggle.labels" -}}
+helm.sh/chart: {{ include "telescope-toggle.chart" . }}
+{{ include "telescope-toggle.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "telescope-toggle.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "telescope-toggle.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "telescope-toggle.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "telescope-toggle.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/telescope-toggle/templates/deployment.yaml
+++ b/charts/telescope-toggle/templates/deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "telescope-toggle.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "telescope-toggle.fullname" . }}
+    chart: {{ template "telescope-toggle.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: {{ include "telescope-toggle.fullname" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "telescope-toggle.fullname" . }}
+        release: {{ .Release.Name }}
+      annotations:
+        alwaysRoll: {{ randAlphaNum 5 | quote }}
+    spec:
+      {{- if .Values.pullSecret.enabled }}
+      imagePullSecrets:
+        - name: {{ .Values.pullSecret.secretName }}
+      {{- end}}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          env:
+          - name: PG_HOST
+            valueFrom:
+              secretKeyRef:
+                key: databaseHost
+                name: {{ .Values.postgresql.secretName }}
+          - name: PG_DATABASE
+            valueFrom:
+              secretKeyRef:
+                key: databaseName
+                name: {{ .Values.postgresql.secretName }}
+          - name: PG_USER
+            valueFrom:
+              secretKeyRef:
+                key: databaseUser
+                name: {{ .Values.postgresql.secretName }}
+          - name: PG_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: databasePassword
+                name: {{ .Values.postgresql.secretName }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetport }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probe.readypath }}
+              port: http
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probe.livepath }}
+              port: http
+{{- if .Values.env }}
+          env:
+            {{- tpl (toYaml .Values.env) . | nindent 12 }}
+{{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/telescope-toggle/templates/postgresql-secret.yaml
+++ b/charts/telescope-toggle/templates/postgresql-secret.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.postgresql.external }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.postgresql.secretName }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": before-hook-creation
+stringData:
+  databaseName: "{{ required "Database Name is required" .Values.postgresql.database }}"
+  databaseUser: "{{ required "Database User is required" .Values.postgresql.user }}"
+  databasePort: "{{ required "Database Port is required" .Values.postgresql.port }}"
+  databaseHost: "{{ required "Database Host is required" .Values.postgresql.host }}"
+  databasePassword: "{{ required "Database Password is required" .Values.postgresql.databasePassword }}"
+{{- end }}

--- a/charts/telescope-toggle/templates/route.yaml
+++ b/charts/telescope-toggle/templates/route.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "telescope-toggle.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  {{- if .Values.route.hostname }}
+  host: {{ .Values.route.hostname }}
+  {{- end}}
+  path: {{ default "/" .path }}
+  port:
+    targetPort: http
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: {{ include "telescope-toggle.fullname" . }}
+{{- end }}

--- a/charts/telescope-toggle/templates/service.yaml
+++ b/charts/telescope-toggle/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "telescope-toggle.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "telescope-toggle.fullname" . }}
+    chart: {{ template "telescope-toggle.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetport }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ include "telescope-toggle.fullname" . }}
+    release: {{ .Release.Name }}

--- a/charts/telescope-toggle/values.schema.json
+++ b/charts/telescope-toggle/values.schema.json
@@ -1,0 +1,269 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+      "image": {
+          "type": "string",
+          "examples": [
+              "quay.io/telescope/telescope-toggle:latest"
+          ]
+      },
+      "imagePullPolicy": {
+          "type": "string",
+          "examples": [
+              "Always"
+          ]
+      },
+      "service": {
+          "type": "object",
+          "properties": {
+              "name": {
+                  "type": "string",
+                  "examples": [
+                      "telescope-toggle"
+                  ]
+              },
+              "type": {
+                  "type": "string",
+                  "examples": [
+                      "ClusterIP"
+                  ]
+              },
+              "port": {
+                  "type": "integer",
+                  "examples": [
+                      80
+                  ]
+              },
+              "targetport": {
+                  "type": "integer",
+                  "examples": [
+                      8080
+                  ]
+              }
+          },
+          "examples": [{
+              "name": "telescope-toggle",
+              "type": "ClusterIP",
+              "port": 80,
+              "targetport": 8080
+          }]
+      },
+      "probe": {
+          "type": "object",
+          "properties": {
+              "readypath": {
+                  "type": "string",
+                  "examples": [
+                      "/"
+                  ]
+              },
+              "livepath": {
+                  "type": "string",
+                  "examples": [
+                      "/"
+                  ]
+              }
+          },
+          "examples": [{
+              "readypath": "/",
+              "livepath": "/"
+          }]
+      },
+      "route": {
+          "type": "object",
+          "properties": {
+              "name": {
+                  "type": "string",
+                  "examples": [
+                      "telescope-toggle"
+                  ]
+              },
+              "enabled": {
+                  "type": "boolean",
+                  "examples": [
+                      true
+                  ]
+              },
+              "annotations": {
+                  "type": "object",
+                  "properties": {},
+                  "examples": [{}]
+              },
+              "path": {
+                  "type": "string",
+                  "examples": [
+                      "/"
+                  ]
+              },
+              "hostname": {
+                  "type": "string",
+                  "examples": [
+                      ""
+                  ]
+              }
+          },
+          "examples": [{
+              "name": "telescope-toggle",
+              "enabled": true,
+              "annotations": {},
+              "path": "/",
+              "hostname": ""
+          }]
+      },
+      "resources": {
+          "type": "null",
+          "examples": [
+              null
+          ]
+      },
+      "nodeSelector": {
+          "type": "object",
+          "properties": {},
+          "examples": [{}]
+      },
+      "tolerations": {
+          "type": "array",
+          "items": {},
+          "examples": [
+              []
+          ]
+      },
+      "affinity": {
+          "type": "object",
+          "properties": {},
+          "examples": [{}]
+      },
+      "pullSecret": {
+          "type": "object",
+          "properties": {
+              "enabled": {
+                  "type": "boolean",
+                  "examples": [
+                      false
+                  ]
+              },
+              "secretName": {
+                  "type": "string",
+                  "examples": [
+                      "pull-secret"
+                  ]
+              },
+              "secretKey": {
+                  "type": "string",
+                  "examples": [
+                      ".dockerconfigjson"
+                  ]
+              }
+          },
+          "examples": [{
+              "enabled": false,
+              "secretName": "pull-secret",
+              "secretKey": ".dockerconfigjson"
+          }]
+      },
+      "postgresql": {
+          "type": "object",
+          "properties": {
+              "external": {
+                  "type": "boolean",
+                  "examples": [
+                      false
+                  ]
+              },
+              "secretName": {
+                  "type": "string",
+                  "examples": [
+                      "postgresql"
+                  ]
+              },
+              "host": {
+                  "type": "string",
+                  "examples": [
+                      "postgresql"
+                  ]
+              },
+              "port": {
+                  "type": "integer",
+                  "examples": [
+                      5432
+                  ]
+              },
+              "username": {
+                  "type": "string",
+                  "examples": [
+                      ""
+                  ]
+              },
+              "password": {
+                  "type": "string",
+                  "examples": [
+                      ""
+                  ]
+              },
+              "adminPassword": {
+                  "type": "string",
+                  "examples": [
+                      ""
+                  ]
+              },
+              "database": {
+                  "type": "string",
+                  "examples": [
+                      "telescope"
+                  ]
+              }
+          },
+          "examples": [{
+              "external": false,
+              "secretName": "postgresql",
+              "host": "postgresql",
+              "port": 5432,
+              "username": "",
+              "password": "",
+              "adminPassword": "",
+              "database": "telescope"
+          }]
+      }
+  },
+  "examples": [{
+      "image": "quay.io/telescope/telescope-toggle:latest",
+      "imagePullPolicy": "Always",
+      "service": {
+          "name": "telescope-toggle",
+          "type": "ClusterIP",
+          "port": 80,
+          "targetport": 8080
+      },
+      "probe": {
+          "readypath": "/",
+          "livepath": "/"
+      },
+      "route": {
+          "name": "telescope-toggle",
+          "enabled": true,
+          "annotations": {},
+          "path": "/",
+          "hostname": ""
+      },
+      "resources": null,
+      "nodeSelector": {},
+      "tolerations": [],
+      "affinity": {},
+      "pullSecret": {
+          "enabled": false,
+          "secretName": "pull-secret",
+          "secretKey": ".dockerconfigjson"
+      },
+      "postgresql": {
+          "external": false,
+          "secretName": "postgresql",
+          "host": "postgresql",
+          "port": 5432,
+          "username": "",
+          "password": "",
+          "adminPassword": "",
+          "database": "telescope"
+      }
+  }]
+}

--- a/charts/telescope-toggle/values.yaml
+++ b/charts/telescope-toggle/values.yaml
@@ -1,0 +1,50 @@
+image: quay.io/telescope/telescope-toggle:latest
+imagePullPolicy: Always
+
+service:
+  name: telescope-toggle
+  type: ClusterIP
+  port: 80
+  targetport: 8080
+
+probe:
+  readypath: /
+  livepath: /
+
+route:
+  name: telescope-toggle
+  enabled: true
+  annotations: {}
+  path: /
+  hostname: ""
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:   #  cpu: 100m
+  #  memory: 128Mi
+  # requests:   #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+pullSecret:
+  enabled: false
+  secretName: "pull-secret"
+  secretKey: ".dockerconfigjson"
+
+postgresql:
+  external: false
+  secretName: postgresql
+  host: postgresql
+  port: 5432
+  username: ""
+  password: ""
+  adminPassword: ""
+  database: "telescope"


### PR DESCRIPTION
Added telescope-toggle chart

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. THe [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content
- [x] JSON Schema generated
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command
