### PR TITLE
Added reusable integration scripts chart

### DIFF
--- a/charts/telescope-integration-scripts/Chart.yaml
+++ b/charts/telescope-integration-scripts/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: telescope-integration-scripts
+description: >-
+  Generic charts to support the tooling to integrate external tooling into Telescope.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0

--- a/charts/telescope-integration-scripts/README.md
+++ b/charts/telescope-integration-scripts/README.md
@@ -1,0 +1,42 @@
+# telescope-integration-scripts
+
+Integration scripts for the [Telescope Project](https://rh-telescope.github.io/)
+
+## Quick Installation
+
+```shell
+helm dependency update .
+helm install [RELEASE_NAME] .
+```
+
+This command deploys the default configuration for the telescope-integration-scripts chart. The [Parameters] section describes the various ways in which the chart can be configured.
+
+## Uninstallation
+
+```shell
+helm uninstall [RELEASE_NAME]
+```
+
+The previous command removes the previously installed chart.
+
+## Parameters
+
+The following table lists the configurable parameters of the telescope-backend chart and their default values.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| image | string | `""` |  |
+| imagePullPolicy | string | `"Always"` |  |
+| nodeSelector | object | `{}` |  |
+| pullSecret.enabled | bool | `false` |  |
+| pullSecret.secretKey | string | `".dockerconfigjson"` |  |
+| pullSecret.secretName | string | `"pull-secret"` |  |
+| replicaCount | int | `1` |  |
+| resources | string | `nil` |  |
+| schedule | string | `"0 * * * *"` |  |
+| tolerations | list | `[]` |  |
+
+----------------------------------------------

--- a/charts/telescope-integration-scripts/templates/_helpers.tpl
+++ b/charts/telescope-integration-scripts/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "telescope-integration-scripts.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "telescope-integration-scripts.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "telescope-integration-scripts.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "telescope-integration-scripts.labels" -}}
+helm.sh/chart: {{ include "postgresql.chart" . }}
+{{ include "telescope-integration-scripts.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "telescope-integration-scripts.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "telescope-integration-scripts.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/telescope-integration-scripts/templates/cronjob.yaml
+++ b/charts/telescope-integration-scripts/templates/cronjob.yaml
@@ -1,0 +1,64 @@
+kind: CronJob
+apiVersion: batch/v1
+metadata:
+  name: {{ include "telescope-integration-scripts.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "telescope-integration-scripts.fullname" . }}
+    chart: {{ template "telescope-integration-scripts.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  schedule: "{{ .Values.schedule }}"
+  concurrencyPolicy: Allow
+  suspend: false
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          {{- if .Values.pullSecret.enabled }}
+          imagePullSecrets:
+            - name: {{ .Values.pullSecret.secretName }}
+          {{- end}}
+          containers:
+            - name: {{ include "telescope-integration-scripts.fullname" . }}
+              image: "{{ required "Image is required" .Values.image }}"
+              env:
+              - name: PG_DB
+                value: 'jdbc:postgresql://{{ .Values.postgresql.host }}:{{ .Values.postgresql.port }}/{{ .Values.postgresql.database }}'
+              - name: PG_USER
+                valueFrom:
+                  secretKeyRef:
+                    key: databaseUser
+                    name: {{ .Values.postgresql.secretName }}
+              - name: PG_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    key: databasePassword
+                    name: {{ .Values.postgresql.secretName }}
+              {{- with .Values.resources }}
+              resources:
+                {{ toYaml . | indent 16 }}
+              {{- end }}
+              terminationMessagePolicy: File
+              imagePullPolicy: Always
+          restartPolicy: Never
+          securityContext: {}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{ toYaml . | indent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{ toYaml . | indent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{ toYaml . | indent 12 }}
+          {{- end }}
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1

--- a/charts/telescope-integration-scripts/values.schema.json
+++ b/charts/telescope-integration-scripts/values.schema.json
@@ -1,0 +1,136 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "type": "object",
+    "properties": {
+        "replicaCount": {
+            "type": "integer",
+            "examples": [
+                1
+            ]
+        },
+        "image": {
+            "type": "string",
+            "examples": [
+                ""
+            ]
+        },
+        "imagePullPolicy": {
+            "type": "string",
+            "examples": [
+                "Always"
+            ]
+        },
+        "schedule": {
+            "type": "string",
+            "examples": [
+                "0 * * * *"
+            ]
+        },
+        "resources": {
+            "type": "null",
+            "examples": [
+                null
+            ]
+        },
+        "nodeSelector": {
+            "type": "object",
+            "properties": {},
+            "examples": [{}]
+        },
+        "tolerations": {
+            "type": "array",
+            "examples": [
+                []
+            ]
+        },
+        "affinity": {
+            "type": "object",
+            "properties": {},
+            "examples": [{}]
+        },
+        "pullSecret": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "examples": [
+                        false
+                    ]
+                },
+                "secretName": {
+                    "type": "string",
+                    "examples": [
+                        "pull-secret"
+                    ]
+                },
+                "secretKey": {
+                    "type": "string",
+                    "examples": [
+                        ".dockerconfigjson"
+                    ]
+                }
+            },
+            "examples": [{
+                "enabled": false,
+                "secretName": "pull-secret",
+                "secretKey": ".dockerconfigjson"
+            }]
+        },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "secretName": {
+                    "type": "string",
+                    "examples": [
+                        "postgresql"
+                    ]
+                },
+                "host": {
+                    "type": "string",
+                    "examples": [
+                        "postgresql"
+                    ]
+                },
+                "port": {
+                    "type": "integer",
+                    "examples": [
+                        5432
+                    ]
+                },
+                "database": {
+                    "type": "string",
+                    "examples": [
+                        "telescope"
+                    ]
+                }
+            },
+            "examples": [{
+                "secretName": "postgresql",
+                "host": "postgresql",
+                "port": 5432,
+                "database": "telescope"
+            }]
+        }
+    },
+    "examples": [{
+        "replicaCount": 1,
+        "image": "",
+        "imagePullPolicy": "Always",
+        "schedule": "0 * * * *",
+        "resources": null,
+        "nodeSelector": {},
+        "tolerations": [],
+        "affinity": {},
+        "pullSecret": {
+            "enabled": false,
+            "secretName": "pull-secret",
+            "secretKey": ".dockerconfigjson"
+        },
+        "postgresql": {
+            "secretName": "postgresql",
+            "host": "postgresql",
+            "port": 5432,
+            "database": "telescope"
+        }
+    }]
+}

--- a/charts/telescope-integration-scripts/values.yaml
+++ b/charts/telescope-integration-scripts/values.yaml
@@ -1,0 +1,33 @@
+replicaCount: 1
+
+image: ""
+imagePullPolicy: Always
+
+schedule: "0 * * * *"
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:   #  cpu: 100m
+  #  memory: 128Mi
+  # requests:   #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+pullSecret:
+  enabled: false
+  secretName: "pull-secret"
+  secretKey: ".dockerconfigjson"
+
+postgresql:
+  secretName: postgresql
+  host: postgresql
+  port: 5432
+  database: "telescope"


### PR DESCRIPTION
 **Description of the change**

New Chart to add automation for external integrations

 **Existing or Associated Issue(s)**

None

 **Additional Information**

Specify the `--set image=<integration_image>` when installing the chart

**Checklist**

- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. THe [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content
- [x] JSON Schema generated
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command
