### PR TITLE
Added method to override chart releaseName

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ helm upgrade -i <release_name> telescope/<chart_name>
 ## Charts
 
 * [telescope-argocd](charts/telescope-argocd)
-* [telescope-frontend](charts/telescope-frontend)
 * [telescope-backend](charts/telescope-backend)
+* [telescope-frontend](charts/telescope-frontend)
+* [telescope-integration-scripts](charts/telescope-integration-scripts)
 * [telescope-toggle](charts/telescope-toggle)
 * [postgresql](charts/postgresql)
 

--- a/charts/telescope-argocd/Chart.yaml
+++ b/charts/telescope-argocd/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: telescope-argocd
 description: Chart to deploy Argo CD Applications Supporting Telescope
-version: 0.2.0
+version: 0.3.0

--- a/charts/telescope-argocd/templates/application.yaml
+++ b/charts/telescope-argocd/templates/application.yaml
@@ -18,7 +18,7 @@ spec:
     repoURL: {{ default $.Values.repoURL $chart.repoURL }}
     targetRevision: {{ default $.Values.chartVersion $chart.chartVersion }}
     helm:
-      releaseName: {{ default $chartName (default $chart.name $chart.repoChart) }}
+      releaseName: {{ default (default $chartName (default $chart.name $chart.repoChart)) $chart.releaseName }}
     {{- if $chart.values }}
       values: |
         {{- toYaml $chart.values | nindent 8 }}


### PR DESCRIPTION
 **Description of the change**

Enables the ability to define a `releaseName` for generated charts

 **Existing or Associated Issue(s)**

None

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. THe [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content
- [x] JSON Schema generated
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command
